### PR TITLE
add charset utf8

### DIFF
--- a/docs/guide/README.md
+++ b/docs/guide/README.md
@@ -172,6 +172,7 @@ const renderer = require('vue-server-renderer').createRenderer({
 const context = {
     title: 'vue ssr',
     meta: `
+        <meta charset="utf-8" />
         <meta name="keyword" content="vue,ssr">
         <meta name="description" content="vue srr demo">
     `,

--- a/docs/ru/guide/README.md
+++ b/docs/ru/guide/README.md
@@ -173,6 +173,7 @@ const renderer = require('vue-server-renderer').createRenderer({
 const context = {
     title: 'vue ssr',
     meta: `
+        <meta charset="utf-8" />
         <meta name="keyword" content="vue,ssr">
         <meta name="description" content="vue ssr demo">
     `,


### PR DESCRIPTION
add charset utf8 to meta.

Because there was garbled text when copying the code, so I added "utf-8" to the meta to solve the garbled text issue.